### PR TITLE
Remove hardcoded region from terragrunt vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV AWS_DEFAULT_REGION="${AWS_REGION}"
 # Terraform vars
 ENV TF_VAR_region="${AWS_REGION}"
 ENV TF_VAR_account_id="323330167063"
+ENV TF_VAR_aws_assume_role_arn="arn:aws:iam::${TF_VAR_account_id}:role/atlantis"
 ENV TF_VAR_namespace="cpco"
 ENV TF_VAR_stage="root"
 

--- a/conf/terraform.tfvars
+++ b/conf/terraform.tfvars
@@ -27,7 +27,6 @@ terragrunt = {
 
       env_vars = {
         TF_VAR_aws_assume_role_arn = "${get_env("TF_VAR_aws_assume_role_arn", "arn:aws:iam::323330167063:role/atlantis")}"
-        AWS_DEFAULT_REGION         = "us-west-2"
       }
     }
   }


### PR DESCRIPTION
## what

This should address https://github.com/cloudposse/root.cloudposse.co/issues/34

See individual commits for more info.

## testing

```
$ make docker/build
$ make install
$ root.cloudposse.co
...SNIP...
 ✗   (none) iam ⨠  echo $AWS_DEFAULT_REGION
us-west-2
-> Run 'assume-role' to login to AWS
-> Run 'init-terraform' to use this project
 ⧉  root.cloudposse.co
 ✗   (none) iam ⨠  echo $TF_VAR_aws_assume_role_arn
arn:aws:iam::323330167063:role/atlantis
```