### PR TITLE
Corrected submodule instructions

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -9,7 +9,7 @@ git submodule init
 ### Add a module
 
 ```
-git submodule add --tag 0.1.0 https://github.com/cloudposse/geodesic-aws-atlantis.git atlantis
+git submodule add https://github.com/cloudposse/geodesic-aws-atlantis.git atlantis
 ```
 
 ### Update a module

--- a/conf/README.md
+++ b/conf/README.md
@@ -1,5 +1,11 @@
 ## Submodules
 
+
+### change from geodessic base to conf/
+```
+cd conf/
+```
+
 ### Init
 
 ```


### PR DESCRIPTION
```
git submodule add --tag ...
``` 

is not valid syntax https://git-scm.com/docs/git-submodule

In relation to geodessic the conf/ path is important 