### PR TITLE
users: Add Josh Myers to testing AWS account

### DIFF
--- a/conf/iam/terraform.tfvars
+++ b/conf/iam/terraform.tfvars
@@ -31,4 +31,5 @@ testing_account_user_names = [
   "erik@cloudposse.com",
   "vadzim@cloudposse.com",
   "aliaksandr@cloudposse.com",
+  "josh",
 ]


### PR DESCRIPTION
## what

Not very happy with the name (not email) but despite what it looks like,
we don’t actually have a naming convention at the moment. My user has
already been setup so continue to use until SSO is implemented.

## testing

I have tested this locally:

```
Terraform will perform the following actions:

  ~ module.organization_access_group_testing.aws_iam_group_membership.default
      users.#:          "4" => "5"
      users.1898940217: "" => "josh"
      users.2992420092: "erik@cloudposse.com" => "erik@cloudposse.com"
      users.3803060854: "admin@cloudposse.co" => "admin@cloudposse.co"
      users.712030059:  "aliaksandr@cloudposse.com" => "aliaksandr@cloudposse.com"
      users.786516976:  "vadzim@cloudposse.com" => "vadzim@cloudposse.com"


Plan: 0 to add, 1 to change, 0 to destroy.
```